### PR TITLE
Feat!: Drop Python 3.8/Alpine 3.14 / Support Python 3.11/Alpine3.18

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,10 +14,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - python: "3.9"
-            alpine: "3.14"
           - python: "3.10"
             alpine: "3.16"
+          - python: "3.11"
+            alpine: "3.18"
     runs-on: ubuntu-latest
     name: Create docker containers
     steps:


### PR DESCRIPTION
With the Alpine 3.18, native support for Python 3.11 comes along. Alpine 3.14 is now deprecated